### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ If you wish to use Spring XD Tuples in you project add the following dependencie
 [subs="attributes"]
 ----
 //Add this repo to your repositories if it does not already exist.
-maven { url "http://repo.spring.io/libs-snapshot"}
+maven { url "https://repo.spring.io/libs-snapshot"}
 
 //Add this dependency
 compile 'org.springframework.xd:spring-xd-tuple:{appversion}'


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/har with 1 occurrences